### PR TITLE
Fix multi-byte integer length calculation

### DIFF
--- a/src/MQTT5.cpp
+++ b/src/MQTT5.cpp
@@ -1017,9 +1017,6 @@ bool MQTT5::writeVariableByteInteger(uint16_t *position, uint16_t length) {
         lenBuf[pos++] = digit;
         llen++;
     } while(len > 0);
-    // Add integer with zero
-    if (len == 0) 
-        llen = 1;
 
     // Check if content fits in buffer
     if ((*position) + llen + length > maxPacketSize) {


### PR DESCRIPTION
This change removes an `if` statement that overrides the length of multi-byte MQTT integers to always be `1`. The value 0 will always result in this being at least 1 because of the do-while loop, so the case I imagine this 'if' was inserted to handle is not an issue in the present design.